### PR TITLE
Removed manual setting of system include paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,11 +56,7 @@ AC_ARG_ENABLE(stacktrace,
 
 
 # Standard installation base dirs.
-if test "$cross_compiling" = yes; then
-  ac_with_paths=""
-else
-  ac_with_paths="/usr /usr/local"
-fi
+ac_with_paths=""
 
 # Set for alternate Qt4/5 installation dir.
 AC_ARG_WITH(qt4,


### PR DESCRIPTION
Manually setting them in "configure.ac" leads to having them
being included via "-isystem" in the generated Makefile. This
leads to issues because "-isystem" would require to manually
include the C++ headers beforehand, the same way. With very
recent compilers like GCC 6, that doesn't work anymore.
